### PR TITLE
Merge any kind of headers

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -69,6 +69,20 @@ describe('addQueryToInput', () => {
     ).toBe('https://example.com/api?id=1&page=2')
   })
 
+  it('should append the query to a URL instance that already has QS', () => {
+    expect(
+      subject.addQueryToInput(new URL('https://example.com/api?id=1'), {
+        page: '2',
+      }),
+    ).toEqual(new URL('https://example.com/api?id=1&page=2'))
+    expect(
+      subject.addQueryToInput(
+        new URL('https://example.com/api?id=1'),
+        'page=2',
+      ),
+    ).toEqual(new URL('https://example.com/api?id=1&page=2'))
+  })
+
   it("should return the input in case there's no query", () => {
     expect(subject.addQueryToInput('https://example.com/api')).toBe(
       'https://example.com/api',
@@ -94,6 +108,18 @@ describe('makeGetApiUrl', () => {
     expect(getApiURL('/users', { active: 'true', page: '2' })).toBe(
       'https://example.com/api/users?active=true&page=2',
     )
+  })
+
+  it('should accept a URL as baseURL and remove extra slashes', () => {
+    expect(
+      subject.makeGetApiUrl(new URL('https://example.com/api'))('/users'),
+    ).toBe('https://example.com/api/users')
+    expect(
+      subject.makeGetApiUrl(new URL('https://example.com/api/'))('/users'),
+    ).toBe('https://example.com/api/users')
+    expect(
+      subject.makeGetApiUrl(new URL('https://example.com/api/'))('///users'),
+    ).toBe('https://example.com/api/users')
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export {
   enhancedFetch,
   makeService,
   makeGetApiUrl,
+  mergeHeaders,
   typedResponse,
 } from './make-service'
 export type * from './types'

--- a/src/make-service.ts
+++ b/src/make-service.ts
@@ -180,7 +180,7 @@ function makeService(baseURL: string | URL, baseHeaders?: HeadersInit) {
    */
   return new Proxy({} as { [K in HTTPMethod]: ReturnType<typeof service> }, {
     get(_target, prop) {
-      if (isHTTPMethod(prop)) return service(prop)
+      if (isHTTPMethod(prop)) return service(prop.toUpperCase() as HTTPMethod)
       throw new Error(`Invalid HTTP method: ${prop.toString()}`)
     },
   })


### PR DESCRIPTION
Ensure all headers get merge, regardless if they are `Headers`, an object, or an array of entries.
It also initiates the `fetch` with an input and requestInit instead of a `Request`.

Adds the possibility to pass an `URL` as `baseUrl` for `makeService` and `makeGetApiUrl`.