### PR TITLE
Replace URL params with the given params

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Its [`typedResponse`](#typedresponse) can also be parsed with a zod schema. Here
 ```ts
 const response = await api.get("/users", {
   query: { search: "John" },
-  trace: (input, requestInit) => console.log(input, requestInit),
+  trace: (url, requestInit) => console.log(url, requestInit),
 })
 const json = await response.json(
   z.object({
@@ -153,7 +153,7 @@ const json = await response.json()
 // You can pass it a generic or schema to type the result
 ```
 
-This function accepts the same arguments as the `fetch` API - with exception of [JSON-like body](/src/make-service.ts) -, and it also accepts an object-like [`query`](/src/make-service.ts) and a `trace` function that will be called with the `input` and `requestInit` arguments.
+This function accepts the same arguments as the `fetch` API - with exception of [JSON-like body](/src/make-service.ts) -, and it also accepts an object-like [`query`](/src/make-service.ts) and a `trace` function that will be called with the `url` and `requestInit` arguments.
 
 This slightly different `RequestInit` is typed as `EnhancedRequestInit`.
 
@@ -164,7 +164,7 @@ await enhancedFetch("https://example.com/api/users", {
   method: 'POST',
   body: { some: { object: { as: { body } } } },
   query: { page: "1" },
-  trace: (input, requestInit) => console.log(input, requestInit)
+  trace: (url, requestInit) => console.log(url, requestInit)
 })
 
 // The trace function will be called with the following arguments:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,11 +1,11 @@
 const HTTP_METHODS = [
-  'get',
-  'post',
-  'put',
-  'delete',
-  'patch',
-  'options',
-  'head',
+  'GET',
+  'POST',
+  'PUT',
+  'DELETE',
+  'PATCH',
+  'OPTIONS',
+  'HEAD',
 ] as const
 
 export { HTTP_METHODS }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -349,7 +349,9 @@ describe('makeService', () => {
   it('should return an object with http methods', () => {
     const api = subject.makeService('https://example.com/api')
     for (const method of HTTP_METHODS) {
-      expect(typeof api[method]).toBe('function')
+      expect(
+        typeof api[method.toLocaleLowerCase() as Lowercase<subject.HTTPMethod>],
+      ).toBe('function')
     }
   })
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -39,36 +39,36 @@ describe('mergeHeaders', () => {
   })
 })
 
-describe('addQueryToInput', () => {
+describe('addQueryToUrl', () => {
   it('should add the query object to a string input', () => {
+    expect(subject.addQueryToUrl('https://example.com/api', { id: '1' })).toBe(
+      'https://example.com/api?id=1',
+    )
     expect(
-      subject.addQueryToInput('https://example.com/api', { id: '1' }),
-    ).toBe('https://example.com/api?id=1')
-    expect(
-      subject.addQueryToInput('https://example.com/api', 'page=2&foo=bar'),
+      subject.addQueryToUrl('https://example.com/api', 'page=2&foo=bar'),
     ).toBe('https://example.com/api?page=2&foo=bar')
   })
 
   it('should add the query object to a URL input', () => {
     expect(
-      subject.addQueryToInput(new URL('https://example.com/api'), {
+      subject.addQueryToUrl(new URL('https://example.com/api'), {
         id: '1',
       }),
     ).toEqual(new URL('https://example.com/api?id=1'))
     expect(
-      subject.addQueryToInput(new URL('https://example.com/api'), 'page=2'),
+      subject.addQueryToUrl(new URL('https://example.com/api'), 'page=2'),
     ).toEqual(new URL('https://example.com/api?page=2'))
   })
 
   it('should append the query to a URL string that already has QS', () => {
     expect(
-      subject.addQueryToInput('https://example.com/api?id=1', { page: '2' }),
+      subject.addQueryToUrl('https://example.com/api?id=1', { page: '2' }),
     ).toBe('https://example.com/api?id=1&page=2')
     expect(
-      subject.addQueryToInput('https://example.com/api?id=1', 'page=2'),
+      subject.addQueryToUrl('https://example.com/api?id=1', 'page=2'),
     ).toBe('https://example.com/api?id=1&page=2')
     expect(
-      subject.addQueryToInput(
+      subject.addQueryToUrl(
         'https://example.com/api?id=1',
         new URLSearchParams({ page: '2' }),
       ),
@@ -77,18 +77,15 @@ describe('addQueryToInput', () => {
 
   it('should append the query to a URL instance that already has QS', () => {
     expect(
-      subject.addQueryToInput(new URL('https://example.com/api?id=1'), {
+      subject.addQueryToUrl(new URL('https://example.com/api?id=1'), {
         page: '2',
       }),
     ).toEqual(new URL('https://example.com/api?id=1&page=2'))
     expect(
-      subject.addQueryToInput(
-        new URL('https://example.com/api?id=1'),
-        'page=2',
-      ),
+      subject.addQueryToUrl(new URL('https://example.com/api?id=1'), 'page=2'),
     ).toEqual(new URL('https://example.com/api?id=1&page=2'))
     expect(
-      subject.addQueryToInput(
+      subject.addQueryToUrl(
         new URL('https://example.com/api?id=1'),
         new URLSearchParams({ page: '2' }),
       ),
@@ -96,10 +93,10 @@ describe('addQueryToInput', () => {
   })
 
   it("should return the input in case there's no query", () => {
-    expect(subject.addQueryToInput('https://example.com/api')).toBe(
+    expect(subject.addQueryToUrl('https://example.com/api')).toBe(
       'https://example.com/api',
     )
-    expect(subject.addQueryToInput(new URL('https://example.com/api'))).toEqual(
+    expect(subject.addQueryToUrl(new URL('https://example.com/api'))).toEqual(
       new URL('https://example.com/api'),
     )
   })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -256,6 +256,24 @@ describe('enhancedFetch', () => {
     })
   })
 
+  it('should replace params in the URL', async () => {
+    vi.spyOn(global, 'fetch').mockImplementationOnce(
+      successfulFetch({ foo: 'bar' }),
+    )
+    await subject.enhancedFetch(
+      'https://example.com/api/users/:user/page/:page',
+      {
+        params: { user: '1', page: '2', foo: 'bar' },
+      },
+    )
+    expect(reqMock).toHaveBeenCalledWith({
+      url: 'https://example.com/api/users/1/page/2',
+      headers: new Headers({
+        'content-type': 'application/json',
+      }),
+    })
+  })
+
   it('should accept a requestInit and a query', async () => {
     vi.spyOn(global, 'fetch').mockImplementationOnce(
       successfulFetch({ foo: 'bar' }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export {
   addQueryToInput,
+  addQueryToUrl,
   ensureStringBody,
   enhancedFetch,
   makeService,

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -1,5 +1,5 @@
 import { HTTP_METHODS } from './constants'
-import { HTTPMethod, Schema } from './types'
+import { HTTPMethod, EnhancedRequestInit, Schema } from './types'
 
 /**
  * It returns the JSON object or throws an error if the response is not ok.
@@ -31,4 +31,23 @@ function isHTTPMethod(method: string | symbol): method is HTTPMethod {
   return HTTP_METHODS.includes(method as HTTPMethod)
 }
 
-export { getJson, getText, isHTTPMethod }
+/**
+ *
+ * @param url the url string or URL object to replace the params
+ * @param params the params map to be replaced in the url
+ * @returns the url with the params replaced and with the same type as the given url
+ */
+function replaceUrlParams(
+  url: string | URL,
+  params: EnhancedRequestInit['params'],
+) {
+  if (!params) return url
+
+  let urlString = String(url)
+  Object.entries(params).forEach(([key, value]) => {
+    urlString = urlString.replace(new RegExp(`:${key}($|\/)`), `${value}$1`)
+  })
+  return url instanceof URL ? new URL(urlString) : urlString
+}
+
+export { getJson, getText, isHTTPMethod, replaceUrlParams }

--- a/src/make-service.ts
+++ b/src/make-service.ts
@@ -1,3 +1,4 @@
+import { HTTP_METHODS } from './constants'
 import { getJson, getText, isHTTPMethod, replaceUrlParams } from './internals'
 import {
   EnhancedRequestInit,
@@ -180,15 +181,12 @@ function makeService(baseURL: string | URL, baseHeaders?: HeadersInit) {
     }
   }
 
-  /**
-   * It returns a proxy that returns the service function for each HTTP method
-   */
-  return new Proxy({} as { [K in HTTPMethod]: ReturnType<typeof service> }, {
-    get(_target, prop) {
-      if (isHTTPMethod(prop)) return service(prop.toUpperCase() as HTTPMethod)
-      throw new Error(`Invalid HTTP method: ${prop.toString()}`)
-    },
-  })
+  let api = {} as Record<Lowercase<HTTPMethod>, ReturnType<typeof service>>
+  for (const method of HTTP_METHODS) {
+    const lowerMethod = method.toLowerCase() as Lowercase<HTTPMethod>
+    api[lowerMethod] = service(method)
+  }
+  return api
 }
 
 export {

--- a/src/make-service.ts
+++ b/src/make-service.ts
@@ -38,29 +38,33 @@ function mergeHeaders(
 }
 
 /**
- * @param input a string or URL to which the query parameters will be added
+ * @param url a string or URL to which the query parameters will be added
  * @param searchParams the query parameters
- * @returns the input with the query parameters added with the same type as the input
+ * @returns the url with the query parameters added with the same type as the url
  */
-function addQueryToInput(
-  input: string | URL,
+function addQueryToUrl(
+  url: string | URL,
   searchParams?: SearchParams,
 ): string | URL {
-  if (!searchParams) return input
+  if (!searchParams) return url
 
-  if (typeof input === 'string') {
-    const separator = input.includes('?') ? '&' : '?'
-    return `${input}${separator}${new URLSearchParams(searchParams)}`
+  if (typeof url === 'string') {
+    const separator = url.includes('?') ? '&' : '?'
+    return `${url}${separator}${new URLSearchParams(searchParams)}`
   }
-  if (searchParams && input instanceof URL) {
+  if (searchParams && url instanceof URL) {
     for (const [key, value] of Object.entries(
       new URLSearchParams(searchParams),
     )) {
-      input.searchParams.set(key, value)
+      url.searchParams.set(key, value)
     }
   }
-  return input
+  return url
 }
+/**
+ * @deprecated method renamed to addQueryToUrl
+ */
+const addQueryToInput = addQueryToUrl
 
 /**
  * @param baseURL the base path to the API
@@ -70,7 +74,7 @@ function makeGetApiUrl(baseURL: string | URL) {
   const base = baseURL instanceof URL ? baseURL.toString() : baseURL
   return (path: string, searchParams?: SearchParams): string | URL => {
     const url = `${base}${path}`.replace(/([^https?:]\/)\/+/g, '$1')
-    return addQueryToInput(url, searchParams)
+    return addQueryToUrl(url, searchParams)
   }
 }
 
@@ -113,7 +117,7 @@ function ensureStringBody(body?: JSONValue): string | undefined {
 
 /**
  *
- * @param input a string or URL to be fetched
+ * @param url a string or URL to be fetched
  * @param requestInit the requestInit to be passed to the fetch request. It is the same as the `RequestInit` type, but it also accepts a JSON-like `body` and an object-like `query` parameter.
  * @param requestInit.body the body of the request. It will be automatically stringified so you can send a JSON-like object
  * @param requestInit.query the query parameters to be added to the URL
@@ -126,7 +130,7 @@ function ensureStringBody(body?: JSONValue): string | undefined {
  * //    ^? unknown
  */
 async function enhancedFetch(
-  input: string | URL,
+  url: string | URL,
   requestInit?: EnhancedRequestInit,
 ) {
   const { query, trace, ...reqInit } = requestInit ?? {}
@@ -188,6 +192,7 @@ function makeService(baseURL: string | URL, baseHeaders?: HeadersInit) {
 
 export {
   addQueryToInput,
+  addQueryToUrl,
   ensureStringBody,
   enhancedFetch,
   makeService,

--- a/src/make-service.ts
+++ b/src/make-service.ts
@@ -1,5 +1,5 @@
-import { getJson, getText, isHTTPMethod } from './internals'
-import type {
+import { getJson, getText, isHTTPMethod, replaceUrlParams } from './internals'
+import {
   EnhancedRequestInit,
   HTTPMethod,
   JSONValue,
@@ -140,12 +140,13 @@ async function enhancedFetch(
     },
     reqInit.headers ?? {},
   )
-  const url = addQueryToInput(input, query)
+  const withParams = replaceUrlParams(url, reqInit.params ?? {})
+  const fullUrl = addQueryToUrl(withParams, query)
   const body = ensureStringBody(reqInit.body)
 
   const enhancedReqInit = { ...reqInit, headers, body }
-  trace?.(url, enhancedReqInit)
-  const response = await fetch(url, enhancedReqInit)
+  trace?.(fullUrl, enhancedReqInit)
+  const response = await fetch(fullUrl, enhancedReqInit)
 
   return typedResponse(response)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ type TypedResponse = Omit<Response, 'json' | 'text'> & {
 type EnhancedRequestInit = Omit<RequestInit, 'body'> & {
   body?: JSONValue
   query?: SearchParams
+  params?: Record<string, string>
   trace?: (...args: Parameters<typeof fetch>) => void
 }
 
@@ -30,10 +31,23 @@ type HTTPMethod = (typeof HTTP_METHODS)[number]
 type TypedResponseJson = ReturnType<typeof getJson>
 type TypedResponseText = ReturnType<typeof getText>
 
+type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}
+
+type NoEmpty<T> = keyof T extends never ? never : T
+type PathParams<T extends string> = NoEmpty<
+  T extends `${infer _}:${infer Param}/${infer Rest}`
+    ? Prettify<{ [K in Param]: string } & PathParams<Rest>>
+    : T extends `${infer _}:${infer Param}`
+    ? { [K in Param]: string }
+    : {}
+>
 export type {
   EnhancedRequestInit,
   HTTPMethod,
   JSONValue,
+  PathParams,
   Schema,
   SearchParams,
   ServiceRequestInit,


### PR DESCRIPTION
- Replaces the URL params with the given params, e.g: `api.get('/users/:id', { params: { id: "1" } })`
- Renames `addQueryToInput` to `addQueryToUrl` and deprecate the old name as an alias
- Avoid returning a proxy from `makeService`.