### PR TITLE
Accept a function for baseHeaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 dist/
 npm
+tsc/

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -408,6 +408,24 @@ describe('makeService', () => {
     })
   })
 
+  it('should accept an async function for dynamic headers', async () => {
+    vi.spyOn(global, 'fetch').mockImplementationOnce(
+      successfulFetch({ foo: 'bar' }),
+    )
+    const api = subject.makeService('https://example.com/api', async () => ({
+      Authorization: 'Bearer 123',
+    }))
+    await api.get('/users')
+    expect(reqMock).toHaveBeenCalledWith({
+      url: 'https://example.com/api/users',
+      headers: new Headers({
+        authorization: 'Bearer 123',
+        'content-type': 'application/json',
+      }),
+      method: 'GET',
+    })
+  })
+
   it('should accept a query, trace, and JSON-like body', async () => {
     const trace = vi.fn()
     vi.spyOn(global, 'fetch').mockImplementationOnce(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -390,6 +390,24 @@ describe('makeService', () => {
     })
   })
 
+  it('should accept a function for dynamic headers', async () => {
+    vi.spyOn(global, 'fetch').mockImplementationOnce(
+      successfulFetch({ foo: 'bar' }),
+    )
+    const api = subject.makeService('https://example.com/api', () => ({
+      Authorization: 'Bearer 123',
+    }))
+    await api.get('/users')
+    expect(reqMock).toHaveBeenCalledWith({
+      url: 'https://example.com/api/users',
+      headers: new Headers({
+        authorization: 'Bearer 123',
+        'content-type': 'application/json',
+      }),
+      method: 'GET',
+    })
+  })
+
   it('should accept a query, trace, and JSON-like body', async () => {
     const trace = vi.fn()
     vi.spyOn(global, 'fetch').mockImplementationOnce(

--- a/src/make-service.ts
+++ b/src/make-service.ts
@@ -165,7 +165,7 @@ async function enhancedFetch(
  */
 function makeService(
   baseURL: string | URL,
-  baseHeaders?: HeadersInit | (() => HeadersInit),
+  baseHeaders?: HeadersInit | (() => HeadersInit | Promise<HeadersInit>),
 ) {
   /**
    * A function that receives a path and requestInit and returns a serialized json response that can be typed or not.
@@ -179,7 +179,9 @@ function makeService(
         ...requestInit,
         method,
         headers: mergeHeaders(
-          typeof baseHeaders === 'function' ? baseHeaders() : baseHeaders ?? {},
+          typeof baseHeaders === 'function'
+            ? await baseHeaders()
+            : baseHeaders ?? {},
           requestInit?.headers ?? {},
         ),
       })

--- a/src/make-service.ts
+++ b/src/make-service.ts
@@ -163,7 +163,10 @@ async function enhancedFetch(
  * const users = await response.json(userSchema);
  * //    ^? User[]
  */
-function makeService(baseURL: string | URL, baseHeaders?: HeadersInit) {
+function makeService(
+  baseURL: string | URL,
+  baseHeaders?: HeadersInit | (() => HeadersInit),
+) {
   /**
    * A function that receives a path and requestInit and returns a serialized json response that can be typed or not.
    * @param method the HTTP method
@@ -175,7 +178,10 @@ function makeService(baseURL: string | URL, baseHeaders?: HeadersInit) {
       const response = await enhancedFetch(url, {
         ...requestInit,
         method,
-        headers: mergeHeaders(baseHeaders ?? {}, requestInit?.headers ?? {}),
+        headers: mergeHeaders(
+          typeof baseHeaders === 'function' ? baseHeaders() : baseHeaders ?? {},
+          requestInit?.headers ?? {},
+        ),
       })
       return response
     }


### PR DESCRIPTION
In order to send rotating JWT tokens at each request, we need to pass `makeService` a function that will be run once for each request. What do you think of this idea, @gustavoguichard?