### PR TITLE
Stop throwing depending on status

### DIFF
--- a/src/internals.ts
+++ b/src/internals.ts
@@ -27,10 +27,6 @@ function getText(response: Response) {
   }
 }
 
-function isHTTPMethod(method: string | symbol): method is HTTPMethod {
-  return HTTP_METHODS.includes(method as HTTPMethod)
-}
-
 /**
  *
  * @param url the url string or URL object to replace the params
@@ -51,4 +47,4 @@ function replaceUrlParams(
   return url instanceof URL ? new URL(urlString) : urlString
 }
 
-export { getJson, getText, isHTTPMethod, replaceUrlParams }
+export { getJson, getText, replaceUrlParams }

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -1,5 +1,4 @@
-import { HTTP_METHODS } from './constants'
-import { HTTPMethod, EnhancedRequestInit, Schema } from './types'
+import { EnhancedRequestInit, Schema } from './types'
 
 /**
  * It returns the JSON object or throws an error if the response is not ok.
@@ -8,9 +7,6 @@ import { HTTPMethod, EnhancedRequestInit, Schema } from './types'
  */
 function getJson(response: Response) {
   return async <T = unknown>(schema?: Schema<T>): Promise<T> => {
-    if (!response.ok) {
-      throw new Error(await response.text())
-    }
     const json = await response.json()
     return schema ? schema.parse(json) : (json as T)
   }

--- a/src/make-service.ts
+++ b/src/make-service.ts
@@ -1,5 +1,5 @@
 import { HTTP_METHODS } from './constants'
-import { getJson, getText, isHTTPMethod, replaceUrlParams } from './internals'
+import { getJson, getText, replaceUrlParams } from './internals'
 import {
   EnhancedRequestInit,
   HTTPMethod,


### PR DESCRIPTION
Closes #7 .
We will stop throwing when `!response.ok` bc some APIs will send JSON content along with error status.

This is a breaking change and will probably be published along with some other changes to take advantage of 1.0 release.