### PR TITLE
Update HTTP methods and improve type of method in RequestInit

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,8 @@ const HTTP_METHODS = [
   'PATCH',
   'OPTIONS',
   'HEAD',
+  'CONNECT',
+  // 'TRACE', it has no support in most browsers yet
 ] as const
 
 export { HTTP_METHODS }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,8 @@ type TypedResponse = Omit<Response, 'json' | 'text'> & {
   text: TypedResponseText
 }
 
-type EnhancedRequestInit = Omit<RequestInit, 'body'> & {
+type EnhancedRequestInit = Omit<RequestInit, 'body' | 'method'> & {
+  method?: HTTPMethod | Lowercase<HTTPMethod>
   body?: JSONValue | BodyInit | null
   query?: SearchParams
   params?: Record<string, string>


### PR DESCRIPTION
Improve `EnhancedRequestInit` with autocompletion for HTTP types.
Adds `CONNECT` HTTP type to complete all possible - and supported - HTTP methods.