### PR TITLE
Add makeFetcher as a primitive of makeService

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export {
   addQueryToURL,
   enhancedFetch,
   ensureStringBody,
+  makeFetcher,
   makeGetApiURL,
   makeService,
   mergeHeaders,


### PR DESCRIPTION
Adds the `makeFetcher` method which is pretty much the same as `makeService` but without the method applied so you have to specify the `method` in the `RequestInit`.

This is useful for creating proxies and other moments where you want to be able to have a configuration for a service but you don't know the method you are going to call in advance.