### PR TITLE
Payload transforms

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -352,36 +352,3 @@ describe('typedResponse', () => {
     expect(result).toEqual({ foo: 'bar' })
   })
 })
-
-describe('transforms', () => {
-  it('should transform object keys', async () => {
-    vi.spyOn(global, 'fetch').mockImplementationOnce(
-      successfulFetch({
-        'some-deep': { 'nested-value': true },
-        'other-value': false,
-      }),
-    )
-    const response = await subject.enhancedFetch(
-      'https://example.com/api/users',
-    )
-    const result = await response.json(
-      z
-        .object({
-          'some-deep': z.object({ 'nested-value': z.boolean() }),
-          'other-value': z.boolean(),
-        })
-        .transform((v) => v),
-    )
-    type _R = Expect<
-      Equal<
-        typeof result,
-        { 'some-deep': { 'nested-value': boolean }; 'other-value': boolean }
-      >
-    >
-
-    expect(result).toEqual({
-      'some-deep': { 'nested-value': true },
-      'other-value': false,
-    })
-  })
-})

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,26 @@ export {
   mergeHeaders,
   replaceURLParams,
 } from './primitives'
+export {
+  camelToKebab,
+  camelToSnake,
+  kebabToCamel,
+  kebabToSnake,
+  snakeToCamel,
+  snakeToKebab,
+} from './transforms'
+export type {
+  CamelToKebab,
+  CamelToSnake,
+  DeepCamelToKebab,
+  DeepCamelToSnake,
+  DeepKebabToCamel,
+  DeepKebabToSnake,
+  DeepSnakeToCamel,
+  DeepSnakeToKebab,
+  KebabToCamel,
+  KebabToSnake,
+  SnakeToCamel,
+  SnakeToKebab,
+} from './transforms'
 export type * from './types'

--- a/src/test.d.ts
+++ b/src/test.d.ts
@@ -1,0 +1,6 @@
+type Expect<T extends true> = T
+type Equal<A, B> =
+  // prettier-ignore
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -1,0 +1,127 @@
+import type * as Subject from './transforms'
+import * as subject from './transforms'
+
+namespace TypeTransforms {
+  type test1 = Expect<
+    Equal<Subject.CamelToKebab<'camelToKebab'>, 'camel-to-kebab'>
+  >
+  type test2 = Expect<
+    Equal<Subject.CamelToSnake<'camelToSnake'>, 'camel_to_snake'>
+  >
+  type test3 = Expect<
+    Equal<Subject.KebabToCamel<'kebab-to-camel'>, 'kebabToCamel'>
+  >
+  type test4 = Expect<
+    Equal<Subject.KebabToSnake<'kebab-to-snake'>, 'kebab_to_snake'>
+  >
+  type test5 = Expect<
+    Equal<Subject.SnakeToCamel<'snake_to_camel'>, 'snakeToCamel'>
+  >
+  type test6 = Expect<
+    Equal<Subject.SnakeToKebab<'snake_to_kebab'>, 'snake-to-kebab'>
+  >
+}
+
+describe('deep transforms', () => {
+  test('camelToKebab', () => {
+    const result = subject.camelToKebab({
+      some: { deepNested: { value: true } },
+      otherValue: true,
+    })
+    expect(result).toEqual({
+      some: { 'deep-nested': { value: true } },
+      'other-value': true,
+    })
+    type test = Expect<
+      Equal<
+        typeof result,
+        { some: { 'deep-nested': { value: boolean } }; 'other-value': boolean }
+      >
+    >
+  })
+
+  test('camelToSnake', () => {
+    const result = subject.camelToSnake({
+      some: { deepNested: { value: true } },
+      otherValue: true,
+    })
+    expect(result).toEqual({
+      some: { deep_nested: { value: true } },
+      other_value: true,
+    })
+    type test = Expect<
+      Equal<
+        typeof result,
+        { some: { deep_nested: { value: boolean } }; other_value: boolean }
+      >
+    >
+  })
+
+  test('kebabToCamel', () => {
+    const result = subject.kebabToCamel({
+      some: { 'deep-nested': { value: true } },
+      'other-value': true,
+    })
+    expect(result).toEqual({
+      some: { deepNested: { value: true } },
+      otherValue: true,
+    })
+    type test = Expect<
+      Equal<
+        typeof result,
+        { some: { deepNested: { value: boolean } }; otherValue: boolean }
+      >
+    >
+  })
+
+  test('kebabToSnake', () => {
+    const result = subject.kebabToSnake({
+      some: { 'deep-nested': { value: true } },
+      'other-value': true,
+    })
+    expect(result).toEqual({
+      some: { deep_nested: { value: true } },
+      other_value: true,
+    })
+    type test = Expect<
+      Equal<
+        typeof result,
+        { some: { deep_nested: { value: boolean } }; other_value: boolean }
+      >
+    >
+  })
+
+  test('snakeToCamel', () => {
+    const result = subject.snakeToCamel({
+      some: { deep_nested: { value: true } },
+      other_value: true,
+    })
+    expect(result).toEqual({
+      some: { deepNested: { value: true } },
+      otherValue: true,
+    })
+    type test = Expect<
+      Equal<
+        typeof result,
+        { some: { deepNested: { value: boolean } }; otherValue: boolean }
+      >
+    >
+  })
+
+  test('snakeToKebab', () => {
+    const result = subject.snakeToKebab({
+      some: { deep_nested: { value: true } },
+      other_value: true,
+    })
+    expect(result).toEqual({
+      some: { 'deep-nested': { value: true } },
+      'other-value': true,
+    })
+    type test = Expect<
+      Equal<
+        typeof result,
+        { some: { 'deep-nested': { value: boolean } }; 'other-value': boolean }
+      >
+    >
+  })
+})

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -1,0 +1,138 @@
+import { typeOf } from './internals'
+
+type KebabToCamel<Str> = Str extends `${infer First}-${infer Rest}`
+  ? `${First}${Capitalize<KebabToCamel<Rest>>}`
+  : Str
+
+type SnakeToCamel<Str> = Str extends `${infer First}_${infer Rest}`
+  ? `${First}${Capitalize<SnakeToCamel<Rest>>}`
+  : Str
+
+type KebabToSnake<Str> = Str extends `${infer First}-${infer Rest}`
+  ? `${First}_${KebabToSnake<Rest>}`
+  : Str
+
+type SnakeToKebab<Str> = Str extends `${infer First}_${infer Rest}`
+  ? `${First}-${SnakeToKebab<Rest>}`
+  : Str
+
+type HandleFirstChar<Str> = Str extends `${infer First}${infer Rest}`
+  ? `${Lowercase<First>}${Rest}`
+  : Str
+
+type CamelToSnakeFn<Str> = Str extends `${infer First}${infer Rest}`
+  ? `${First extends Capitalize<First>
+      ? '_'
+      : ''}${Lowercase<First>}${CamelToSnakeFn<Rest>}`
+  : Str
+
+type CamelToSnake<Str> = CamelToSnakeFn<HandleFirstChar<Str>>
+
+type CamelToKebabFn<Str> = Str extends `${infer First}${infer Rest}`
+  ? `${First extends Capitalize<First>
+      ? '-'
+      : ''}${Lowercase<First>}${CamelToKebabFn<Rest>}`
+  : Str
+
+type CamelToKebab<Str> = CamelToKebabFn<HandleFirstChar<Str>>
+
+function words(str: string) {
+  const matches = str.match(
+    /[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g,
+  )
+  return matches ? Array.from(matches) : [str]
+}
+
+function toCamelCase(str: string) {
+  const result = words(str)
+    .map((x) => x.slice(0, 1).toUpperCase() + x.slice(1).toLowerCase())
+    .join('')
+  return result.slice(0, 1).toLowerCase() + result.slice(1)
+}
+
+function toKebabCase(str: string) {
+  return words(str)
+    .map((x) => x.toLowerCase())
+    .join('-')
+}
+
+function toSnakeCase(str: string) {
+  return words(str)
+    .map((x) => x.toLowerCase())
+    .join('_')
+}
+
+function deepTransformKeys<T>(obj: T, transform: (s: string) => string): T {
+  if (typeOf(obj) !== 'object') return obj
+
+  const res = {} as T
+  for (const key in obj) {
+    res[transform(key) as keyof T] = deepTransformKeys(obj[key], transform)
+  }
+  return res
+}
+
+type DeepKebabToCamel<T> = T extends Record<string, any>
+  ? { [K in keyof T as KebabToCamel<K>]: DeepKebabToCamel<T[K]> }
+  : T
+function kebabToCamel<T>(obj: T): DeepKebabToCamel<T> {
+  return deepTransformKeys(obj, toCamelCase) as never
+}
+
+type DeepSnakeToCamel<T> = T extends Record<string, any>
+  ? { [K in keyof T as SnakeToCamel<K>]: DeepSnakeToCamel<T[K]> }
+  : T
+function snakeToCamel<T>(obj: T): DeepSnakeToCamel<T> {
+  return deepTransformKeys(obj, toCamelCase) as never
+}
+
+type DeepCamelToSnake<T> = T extends Record<string, any>
+  ? { [K in keyof T as CamelToSnake<K>]: DeepCamelToSnake<T[K]> }
+  : T
+function camelToSnake<T>(obj: T): DeepCamelToSnake<T> {
+  return deepTransformKeys(obj, toSnakeCase) as never
+}
+
+type DeepCamelToKebab<T> = T extends Record<string, any>
+  ? { [K in keyof T as CamelToKebab<K>]: DeepCamelToKebab<T[K]> }
+  : T
+function camelToKebab<T>(obj: T): DeepCamelToKebab<T> {
+  return deepTransformKeys(obj, toKebabCase) as never
+}
+
+type DeepSnakeToKebab<T> = T extends Record<string, any>
+  ? { [K in keyof T as SnakeToKebab<K>]: DeepSnakeToKebab<T[K]> }
+  : T
+function snakeToKebab<T>(obj: T): DeepSnakeToKebab<T> {
+  return deepTransformKeys(obj, toKebabCase) as never
+}
+
+type DeepKebabToSnake<T> = T extends Record<string, any>
+  ? { [K in keyof T as KebabToSnake<K>]: DeepKebabToSnake<T[K]> }
+  : T
+function kebabToSnake<T>(obj: T): DeepKebabToSnake<T> {
+  return deepTransformKeys(obj, toSnakeCase) as never
+}
+
+export type {
+  CamelToKebab,
+  CamelToSnake,
+  DeepCamelToKebab,
+  DeepCamelToSnake,
+  DeepKebabToCamel,
+  DeepKebabToSnake,
+  DeepSnakeToCamel,
+  DeepSnakeToKebab,
+  KebabToCamel,
+  KebabToSnake,
+  SnakeToCamel,
+  SnakeToKebab,
+}
+export {
+  camelToKebab,
+  camelToSnake,
+  kebabToCamel,
+  kebabToSnake,
+  snakeToCamel,
+  snakeToKebab,
+}


### PR DESCRIPTION
Adds a series of strongly-typed transformers to use on payloads before sending to the server or after the response gets from the server.

These transformers are going to deeply transform all the keys of objects and the types will follow:
```ts
const result = camelToKebab({ some: { deepValue: true } })
//        ^? { some: { 'deep-value': boolean } }
```