### PR TITLE
Strongly-typed params

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It adds a set of little features and allows you to parse responses with [zod](ht
 - 🤩 Type-safe return of `response.json()` and `response.text()`. Defaults to `unknown` instead of `any`.
 - 🚦 Easily setup an API with a `baseURL` and common `headers` for every request.
 - 🏗️ Compose URL from the base by just calling the endpoints and an object-like `query`.
-- 🐾 Replaces URL wildcards with an object of `params`.
+- 🐾 Replaces URL wildcards with a **strongly-typed** object of `params`.
 - 🧙‍♀️ Automatically stringifies the `body` of a request so you can give it a JSON-like structure.
 - 🐛 Accepts a `trace` function for debugging.
 
@@ -274,6 +274,12 @@ const response = await service.get("/users/:id/article/:articleId", {
 
 // It will call "https://example.com/api/users/2/article/3"
 ```
+The `params` object will not type-check if the given object doesn't follow the path structure.
+```ts
+// @ts-expect-error
+service.get("/users/:id", { params: { id: "2", foobar: "foo" } })
+```
+
 This is achieved by using the [`replaceURLParams`](#replaceurlparams) function internally.
 
 ### Trace
@@ -502,6 +508,8 @@ const url = replaceURLParams(
 )
 // It will return: "https://example.com/users/2/posts/3"
 ```
+
+The params will be **strongly-typed** which means they will be validated against the URL structure and will not type-check if the given object does not match that structure.
 
 # Acknowledgements
 This library is part of a code I've been carrying around for a while through many projects.

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -107,7 +107,12 @@ describe('enhancedFetch', () => {
     await subject.enhancedFetch(
       'https://example.com/api/users/:user/page/:page',
       {
-        params: { user: '1', page: '2', foo: 'bar' },
+        params: {
+          user: '1',
+          page: '2',
+          // @ts-expect-error
+          foo: 'bar',
+        },
       },
     )
     expect(reqMock).toHaveBeenCalledWith({
@@ -211,10 +216,10 @@ describe('makeFetcher', () => {
     vi.spyOn(global, 'fetch').mockImplementationOnce(
       successfulFetch({ foo: 'bar' }),
     )
-    const service = subject.makeFetcher('https://example.com/api', {
+    const fetcher = subject.makeFetcher('https://example.com/api', {
       Authorization: 'Bearer 123',
     })
-    await service('/users')
+    await fetcher('/users')
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users',
       headers: new Headers({
@@ -224,14 +229,32 @@ describe('makeFetcher', () => {
     })
   })
 
+  it('should accept a typed params object', async () => {
+    vi.spyOn(global, 'fetch').mockImplementationOnce(
+      successfulFetch({ foo: 'bar' }),
+    )
+    const fetcher = subject.makeFetcher('https://example.com/api')
+    await fetcher('/users/:id', {
+      params: {
+        id: '1',
+        // @ts-expect-error
+        foo: 'bar',
+      },
+    })
+    expect(reqMock).toHaveBeenCalledWith({
+      url: 'https://example.com/api/users/1',
+      headers: new Headers({ 'content-type': 'application/json' }),
+    })
+  })
+
   it('should accept a function for dynamic headers', async () => {
     vi.spyOn(global, 'fetch').mockImplementationOnce(
       successfulFetch({ foo: 'bar' }),
     )
-    const service = subject.makeFetcher('https://example.com/api', () => ({
+    const fetcher = subject.makeFetcher('https://example.com/api', () => ({
       Authorization: 'Bearer 123',
     }))
-    await service('/users')
+    await fetcher('/users')
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users',
       headers: new Headers({
@@ -245,13 +268,13 @@ describe('makeFetcher', () => {
     vi.spyOn(global, 'fetch').mockImplementationOnce(
       successfulFetch({ foo: 'bar' }),
     )
-    const service = subject.makeFetcher(
+    const fetcher = subject.makeFetcher(
       'https://example.com/api',
       async () => ({
         Authorization: 'Bearer 123',
       }),
     )
-    await service('/users')
+    await fetcher('/users')
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users',
       headers: new Headers({
@@ -266,8 +289,8 @@ describe('makeFetcher', () => {
     vi.spyOn(global, 'fetch').mockImplementationOnce(
       successfulFetch({ foo: 'bar' }),
     )
-    const service = subject.makeFetcher('https://example.com/api')
-    await service('/users', {
+    const fetcher = subject.makeFetcher('https://example.com/api')
+    await fetcher('/users', {
       method: 'POST',
       body: { id: 1, name: { first: 'John', last: 'Doe' } },
       query: { admin: 'true' },
@@ -308,6 +331,25 @@ describe('makeService', () => {
       url: 'https://example.com/api/users',
       headers: new Headers({ 'content-type': 'application/json' }),
       method: 'POST',
+    })
+  })
+
+  it('should accept a typed params object', async () => {
+    vi.spyOn(global, 'fetch').mockImplementationOnce(
+      successfulFetch({ foo: 'bar' }),
+    )
+    const service = subject.makeService('https://example.com/api')
+    await service.get('/users/:id', {
+      params: {
+        id: '1',
+        // @ts-expect-error
+        foo: 'bar',
+      },
+    })
+    expect(reqMock).toHaveBeenCalledWith({
+      url: 'https://example.com/api/users/1',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      method: 'GET',
     })
   })
 })

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -1,4 +1,4 @@
-import { EnhancedRequestInit, Schema } from './types'
+import { Schema } from './types'
 
 /**
  * It returns the JSON object or throws an error if the response is not ok.

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -1,5 +1,5 @@
 import { typeOf } from './internals'
-import { JSONValue, Params, SearchParams } from './types'
+import { JSONValue, PathParams, SearchParams } from './types'
 
 /**
  * @param url a string or URL to which the query parameters will be added
@@ -92,7 +92,7 @@ function mergeHeaders(
  */
 function replaceURLParams<T extends string | URL>(
   url: T,
-  params: Params<T>,
+  params: PathParams<T>,
 ): T {
   // TODO: use the URL Pattern API as soon as it has better browser support
   if (!params) return url as T

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -1,5 +1,5 @@
 import { typeOf } from './internals'
-import { EnhancedRequestInit, JSONValue, SearchParams } from './types'
+import { JSONValue, Params, SearchParams } from './types'
 
 /**
  * @param url a string or URL to which the query parameters will be added
@@ -91,8 +91,8 @@ function mergeHeaders(
  * @returns the url with the params replaced and with the same type as the given url
  */
 function replaceURLParams<T extends string | URL>(
-  url: string | URL,
-  params: EnhancedRequestInit['params'],
+  url: T,
+  params: Params<T>,
 ): T {
   // TODO: use the URL Pattern API as soon as it has better browser support
   if (!params) return url as T

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,15 +17,21 @@ type TypedResponse = Omit<Response, 'json' | 'text'> & {
   text: TypedResponseText
 }
 
-type EnhancedRequestInit = Omit<RequestInit, 'body' | 'method'> & {
+type Params<T> = T extends string
+  ? PathParams<T> extends never
+    ? Record<string, string>
+    : PathParams<T>
+  : Record<string, string>
+
+type EnhancedRequestInit<T = string> = Omit<RequestInit, 'body' | 'method'> & {
   method?: HTTPMethod | Lowercase<HTTPMethod>
   body?: JSONValue | BodyInit | null
   query?: SearchParams
-  params?: Record<string, string>
+  params?: Params<T>
   trace?: (...args: Parameters<typeof fetch>) => void
 }
 
-type ServiceRequestInit = Omit<EnhancedRequestInit, 'method'>
+type ServiceRequestInit<T = string> = Omit<EnhancedRequestInit<T>, 'method'>
 
 type HTTPMethod = (typeof HTTP_METHODS)[number]
 
@@ -36,18 +42,18 @@ type Prettify<T> = {
   [K in keyof T]: T[K]
 } & {}
 
-type NoEmpty<T> = keyof T extends never ? never : T
-type PathParams<T extends string> = NoEmpty<
+type PathParams<T extends string> =
   T extends `${infer _}:${infer Param}/${infer Rest}`
-    ? Prettify<{ [K in Param]: string } & PathParams<Rest>>
+    ? Prettify<Omit<{ [K in Param]: string } & PathParams<Rest>, ''>>
     : T extends `${infer _}:${infer Param}`
     ? { [K in Param]: string }
     : {}
->
+
 export type {
   EnhancedRequestInit,
   HTTPMethod,
   JSONValue,
+  Params,
   PathParams,
   Schema,
   SearchParams,

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,17 +17,17 @@ type TypedResponse = Omit<Response, 'json' | 'text'> & {
   text: TypedResponseText
 }
 
-type Params<T> = T extends string
-  ? PathParams<T> extends never
-    ? Record<string, string>
-    : PathParams<T>
+type PathParams<T> = T extends string
+  ? ExtractPathParams<T> extends Record<string, unknown>
+    ? ExtractPathParams<T>
+    : Record<string, string>
   : Record<string, string>
 
 type EnhancedRequestInit<T = string> = Omit<RequestInit, 'body' | 'method'> & {
   method?: HTTPMethod | Lowercase<HTTPMethod>
   body?: JSONValue | BodyInit | null
   query?: SearchParams
-  params?: Params<T>
+  params?: PathParams<T>
   trace?: (...args: Parameters<typeof fetch>) => void
 }
 
@@ -42,9 +42,9 @@ type Prettify<T> = {
   [K in keyof T]: T[K]
 } & {}
 
-type PathParams<T extends string> =
+type ExtractPathParams<T extends string> =
   T extends `${infer _}:${infer Param}/${infer Rest}`
-    ? Prettify<Omit<{ [K in Param]: string } & PathParams<Rest>, ''>>
+    ? Prettify<Omit<{ [K in Param]: string } & ExtractPathParams<Rest>, ''>>
     : T extends `${infer _}:${infer Param}`
     ? { [K in Param]: string }
     : {}
@@ -53,7 +53,6 @@ export type {
   EnhancedRequestInit,
   HTTPMethod,
   JSONValue,
-  Params,
   PathParams,
   Schema,
   SearchParams,


### PR DESCRIPTION
Make sure the `params` object will type-check according to the given url structure.