### PR TITLE
fix: Add 'Date', 'undefined', and 'null' as possible JSON values to improve DX

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,9 @@ type JSONValue =
   | string
   | number
   | boolean
-  | { [x: string]: JSONValue }
-  | Array<JSONValue>
+  | Date // Will be turned into a string
+  | { [x: string]: JSONValue | undefined | null }
+  | Array<JSONValue | undefined | null>
 
 type SearchParams = ConstructorParameters<typeof URLSearchParams>[0]
 


### PR DESCRIPTION
Should close #31 and #28

Reasoning: if a `Date` is given in the body of a request, it will be turned into a `string`, we are not checking the return type here, we are just allowing the user to send a Date that we know will be stringified by JS.
![Screenshot 2023-09-20 at 10 29 34](https://github.com/gustavoguichard/make-service/assets/566971/9ab26a47-aefb-46d3-a03e-ae15703f00c1)


As for `null` and `undefined`, they are allowed as values of a `Record` or `Array` that will be stringified and the `undefined` values will disappear.
When sending a plain `undefined` though the returning value will not be a string:
![Screenshot 2023-09-20 at 10 30 03](https://github.com/gustavoguichard/make-service/assets/566971/087679de-b06c-4125-8d76-a645335d8270)
