### PR TITLE
feat: add more strict function definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 npm
 tsc/
 .DS_Store
+.idea

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -5,15 +5,15 @@ import type { JSONValue, PathParams, SearchParams } from './types'
  * @param searchParams the query parameters
  * @returns the url with the query parameters added with the same type as the url
  */
-function addQueryToURL(
-  url: string | URL,
+function addQueryToURL<T extends string | URL>(
+  url: T,
   searchParams?: SearchParams,
-): string | URL {
+): T {
   if (!searchParams) return url
 
   if (typeof url === 'string') {
     const separator = url.includes('?') ? '&' : '?'
-    return `${url}${separator}${new URLSearchParams(searchParams)}`
+    return `${url}${separator}${new URLSearchParams(searchParams)}` as T
   }
   if (searchParams && url instanceof URL) {
     for (const [key, value] of new URLSearchParams(searchParams).entries()) {


### PR DESCRIPTION
Currently `addQueryToURL` returns a union type forcing to always do some kind of type narrowing to the answer, even when is not necessary taking into account that in runtime the output will always have the same type of the input.

Before:

```
function onlyAcceptUrl(input: URL){...}
function onlyAcceptString(input: string){...}

const result = addQueryToURL(new URL('https://example.com/api?id=1'), {
     page: '2',
})
onlyAcceptURL(result instanceof URL ? result : new URL(result))
// OR
onlyAcceptURL(result as URL)

const result2 = addQueryToURL('https://example.com/api?id=1', {
     page: '2',
})
onlyAcceptURL(typeof result2 === "string" ? result : result.toString())
// OR
onlyAcceptURL(result2 as string)
```

Now:
```
function onlyAcceptUrl(input: URL){...}
function onlyAcceptString(input: string){...}

const result = addQueryToURL(new URL('https://example.com/api?id=1'), {
     page: '2',
})
onlyAcceptURL(result)

const result2 = addQueryToURL('https://example.com/api?id=1', {
     page: '2',
})
onlyAcceptURL(result2)
```