### PR TITLE
Drop the behavior of adding a default `content-type: application/json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ On the example above, the request will be sent with the following arguments:
 // {
 //   method: 'GET',
 //   headers: {
-//    'content-type': 'application/json',
 //    'authorization': 'Bearer 123',
 //   }
 // }
@@ -202,7 +201,7 @@ const service = makeService("https://example.com/api", {
 })
 
 const response = await service.get("/users", {
-  headers: new Headers({ authorization: 'undefined', "Content-Type": undefined }),
+  headers: new Headers({ authorization: 'undefined' }),
 })
 // headers will be empty.
 ```
@@ -344,7 +343,7 @@ const service = makeService("https://example.com/api")
 const response = await service.get("/users/:id", {
   params: { id: "2" },
   query: { page: "2"},
-  headers: { Accept: "application/json" },
+  headers: { Accept: "application/json", "Content-type": "application/json" },
   trace: (url, requestInit) => {
     console.log("The request was sent to " + url)
     console.log("with the following params: " + JSON.stringify(requestInit))
@@ -408,11 +407,8 @@ await enhancedFetch("https://example.com/api/users/:role", {
 // {
 //   method: 'POST',
 //   body: '{"some":{"object":{"as":{"body":{}}}}}',
-//   headers: { 'content-type': 'application/json' }
 // }
 ```
-
-Notice: the `enhancedFetch` adds a `'content-type': 'application/json'` header by default.
 
 ## typedResponse
 

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -134,9 +134,6 @@ describe('enhancedFetch', () => {
     )
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users/1/page/2',
-      headers: new Headers({
-        'content-type': 'application/json',
-      }),
     })
   })
 
@@ -150,10 +147,7 @@ describe('enhancedFetch', () => {
     })
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users?admin=true',
-      headers: new Headers({
-        authorization: 'Bearer 123',
-        'content-type': 'application/json',
-      }),
+      headers: { Authorization: 'Bearer 123' },
     })
   })
 
@@ -167,7 +161,6 @@ describe('enhancedFetch', () => {
     })
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users',
-      headers: new Headers({ 'content-type': 'application/json' }),
       method: 'POST',
       body: `{"id":1,"name":{"first":"John","last":"Doe"}}`,
     })
@@ -183,7 +176,6 @@ describe('enhancedFetch', () => {
     })
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users',
-      headers: new Headers({ 'content-type': 'application/json' }),
       method: 'POST',
       body: `{"id":1,"name":{"first":"John","last":"Doe"}}`,
     })
@@ -203,7 +195,6 @@ describe('enhancedFetch', () => {
     expect(trace).toHaveBeenCalledWith(
       'https://example.com/api/users?admin=true',
       {
-        headers: new Headers({ 'content-type': 'application/json' }),
         method: 'POST',
         body: `{"id":1,"name":{"first":"John","last":"Doe"}}`,
       },
@@ -221,11 +212,12 @@ describe('makeFetcher', () => {
       r.json(z.object({ foo: z.string() })),
     )
     type _R = Expect<Equal<typeof result, { foo: string }>>
+
     expect(result).toEqual({ foo: 'bar' })
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users',
-      headers: new Headers({ 'content-type': 'application/json' }),
       method: 'post',
+      headers: new Headers(),
     })
   })
 
@@ -238,7 +230,7 @@ describe('makeFetcher', () => {
         Authorization: 'Bearer 123',
       },
     })
-    await fetcher('/users')
+    await fetcher('/users', { headers: { 'Content-type': 'application/json' } })
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users',
       headers: new Headers({
@@ -261,10 +253,7 @@ describe('makeFetcher', () => {
     await fetcher('/users')
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users?foo=bar',
-      headers: new Headers({
-        authorization: 'Bearer 123',
-        'content-type': 'application/json',
-      }),
+      headers: new Headers({ authorization: 'Bearer 123' }),
     })
   })
 
@@ -285,10 +274,7 @@ describe('makeFetcher', () => {
     expect(response.statusText).toEqual('Foo Bar')
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users',
-      headers: new Headers({
-        authorization: 'Bearer 123',
-        'content-type': 'application/json',
-      }),
+      headers: new Headers({ authorization: 'Bearer 123' }),
     })
   })
 
@@ -306,7 +292,7 @@ describe('makeFetcher', () => {
     })
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users/1',
-      headers: new Headers({ 'content-type': 'application/json' }),
+      headers: new Headers(),
     })
   })
 
@@ -322,10 +308,7 @@ describe('makeFetcher', () => {
     await fetcher('/users')
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users',
-      headers: new Headers({
-        authorization: 'Bearer 123',
-        'content-type': 'application/json',
-      }),
+      headers: new Headers({ authorization: 'Bearer 123' }),
     })
   })
 
@@ -338,7 +321,9 @@ describe('makeFetcher', () => {
         Authorization: 'Bearer 123',
       }),
     })
-    await fetcher('/users')
+    await fetcher('/users', {
+      headers: new Headers({ 'content-type': 'application/json' }),
+    })
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users',
       headers: new Headers({
@@ -363,9 +348,9 @@ describe('makeFetcher', () => {
     expect(trace).toHaveBeenCalledWith(
       'https://example.com/api/users?admin=true',
       {
-        headers: new Headers({ 'content-type': 'application/json' }),
         method: 'POST',
         body: `{"id":1,"name":{"first":"John","last":"Doe"}}`,
+        headers: new Headers(),
       },
     )
   })
@@ -390,11 +375,12 @@ describe('makeService', () => {
       .post('/users')
       .then((r) => r.json(z.object({ foo: z.string() })))
     type _R = Expect<Equal<typeof result, { foo: string }>>
+
     expect(result).toEqual({ foo: 'bar' })
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users',
-      headers: new Headers({ 'content-type': 'application/json' }),
       method: 'POST',
+      headers: new Headers(),
     })
   })
 
@@ -412,8 +398,8 @@ describe('makeService', () => {
     })
     expect(reqMock).toHaveBeenCalledWith({
       url: 'https://example.com/api/users/1',
-      headers: new Headers({ 'content-type': 'application/json' }),
       method: 'GET',
+      headers: new Headers(),
     })
   })
 })

--- a/src/api.ts
+++ b/src/api.ts
@@ -73,17 +73,11 @@ async function enhancedFetch<T extends string | URL>(
   requestInit?: EnhancedRequestInit<T>,
 ) {
   const { query, trace, ...reqInit } = requestInit ?? {}
-  const headers = mergeHeaders(
-    {
-      'content-type': 'application/json',
-    },
-    reqInit.headers ?? {},
-  )
+  const body = ensureStringBody(reqInit.body)
   const withParams = replaceURLParams<T>(url, reqInit.params ?? ({} as never))
   const fullURL = addQueryToURL(withParams, query)
-  const body = ensureStringBody(reqInit.body)
 
-  const enhancedReqInit = { ...reqInit, headers, body }
+  const enhancedReqInit = { ...reqInit, body }
   trace?.(fullURL, enhancedReqInit)
   const response = await fetch(fullURL, enhancedReqInit)
 


### PR DESCRIPTION
I'm dropping this default as the content-type could vary a lot depending on the type of the body and most browsers already set the correct content-type.

This is a breaking change and will probably be published only on V3.

This should fix #44 