### PR TITLE
fix(typedResponse): bind remaining Proxy methods to Response

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -209,6 +209,12 @@ describe('enhancedFetch', () => {
       },
     )
   })
+
+  it('should return some result from other Response methods', async () => {
+    const response = await subject.enhancedFetch('data:text/plain;,foo')
+    const blob = await response.blob()
+    expect(await blob.text()).toEqual('foo')
+  })
 })
 
 describe('makeFetcher', () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -46,7 +46,14 @@ function typedResponse(
     get(target, prop) {
       if (prop === 'json') return getJsonFn(target)
       if (prop === 'text') return getTextFn(target)
-      return target[prop as keyof Response]
+
+      const value = Reflect.get(target, prop)
+
+      if (typeof value === 'function') {
+        return value.bind(target)
+      }
+
+      return value
     },
   }) as Omit<Response, 'json' | 'text'> & {
     json: TypedResponseJson


### PR DESCRIPTION
> Please note the important detail in the get trap, in the line (*):
> Why do we need a function to call value.bind(target)?
> The reason is that object methods, such as user.checkPassword(), must be able to access _password:
> – https://javascript.info/proxy

Closes #46 