### PR TITLE
fix(makeFetcher): include requestTransformer headers

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -117,6 +117,7 @@ function makeFetcher(baseURL: string | URL, baseOptions: BaseOptions = {}) {
       ...ri,
       headers: mergeHeaders(
         typeof headers === 'function' ? await headers() : headers ?? {},
+        ri.headers ?? {},
         requestInit?.headers ?? {},
       ),
     })


### PR DESCRIPTION
I tried to use `requestTransformer` to add some custom headers, but it seems those headers are ignored. This PR should fix it.