### PR TITLE
Request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ const users = await response.json(usersSchema);
     - [Transformers](#transformers)
       - [Request transformers](#request-transformers)
       - [Response transformers](#response-transformers)
+    - [Request timeout](#request-timeout)
     - [Body](#body)
     - [Query](#query)
     - [Params](#params)
@@ -256,6 +257,24 @@ const service = makeService('https://example.com/api', {
 const response = await service.get("/users")
 
 // response.statusText will be 'It worked!'
+```
+
+### Request timeout
+
+A single timeout based on the service can be very useful since the default fetch timeout is quite long.
+The `timeout` parameter accepts a number of milliseconds and abort any request that takes longer than that limit.
+
+Using an [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) for individual requests is still possible for more fine grained control.
+
+The example below will abort the request after 30 seconds rejecting the promise.
+
+```ts
+const service = makeService('https://example.com/api', {
+  timeout: 30000,
+})
+
+const response = await service.get("/users")
+
 ```
 
 ### Body

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -227,6 +227,22 @@ describe('makeFetcher', () => {
     })
   })
 
+  it('should accept a timeout in ms', async () => {
+    vi.spyOn(global, 'fetch').mockImplementationOnce(
+      async (_input: URL | RequestInfo, _init?: RequestInit | undefined) => {
+        await new Promise((r) => setTimeout(r, 2000))
+        return new Response(JSON.stringify({ foo: 'bar' }))
+      },
+    )
+    const service = subject.makeFetcher('https://example.com/api', {
+      timeout: 1,
+    })
+    await expect(() =>
+      service('/users', { method: 'post' }).then((r) => r.json()),
+    ).rejects.toThrowError()
+    expect(reqMock).not.toHaveBeenCalled()
+  })
+
   it('should add headers to the request', async () => {
     vi.spyOn(global, 'fetch').mockImplementationOnce(
       successfulFetch({ foo: 'bar' }),

--- a/src/api.ts
+++ b/src/api.ts
@@ -98,6 +98,7 @@ async function enhancedFetch<T extends string | URL>(
  * @param baseOptions.headers any headers that should be sent with every request
  * @param baseOptions.requestTransformer a function that will transform the enhanced request init of every request
  * @param baseOptions.responseTransformer a function that will transform the typed response of every request
+ * @param baseOptions.timeout the maximum number of milliseconds any request is allowed before the promise is rejected.
  * @returns a function that receive a path and requestInit and return a serialized json response that can be typed or not.
  * @example const headers = { Authorization: "Bearer 123" }
  * const fetcher = makeFetcher("https://example.com/api", headers);
@@ -153,6 +154,7 @@ function makeFetcher(baseURL: string | URL, baseOptions: BaseOptions = {}) {
  * @param baseOptions.headers any headers that should be sent with every request
  * @param baseOptions.requestTransformer a function that will transform the enhanced request init of every request
  * @param baseOptions.responseTransformer a function that will transform the typed response of every request
+ * @param baseOptions.timeout the maximum number of milliseconds any request is allowed before the promise is rejected.
  * @returns a service object with HTTP methods that are functions that receive a path and requestInit and return a serialized json response that can be typed or not.
  * @example const headers = { Authorization: "Bearer 123" }
  * const api = makeService("https://example.com/api", headers);

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ type BaseOptions = {
   headers?: HeadersInit | (() => HeadersInit | Promise<HeadersInit>)
   requestTransformer?: RequestTransformer
   responseTransformer?: ResponseTransformer
+  timeout?: number
 }
 
 type HTTPMethod = (typeof HTTP_METHODS)[number]


### PR DESCRIPTION
The idea is to be able to configure a timeout for every call of a service (or fetcher).

This avoids the awkward code necessary to configure a timeout for each request.
It makes sense since the timeout usually is a trait of the target server (the same for several endpoints).

We should still allow the same API to be used on an individual request.