### PR TITLE
Improve parsing errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export {
   mergeHeaders,
   replaceURLParams,
   typeOf,
+  ParseResponseError,
 } from './primitives'
 export type * from './types'

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -1,5 +1,6 @@
-import type { StandardSchemaV1 } from 'zod/lib/standard-schema'
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { GetJson, GetText } from './types'
+import { ParseResponseError } from './primitives'
 
 /**
  * It returns the JSON object or throws an error if the response is not ok.
@@ -12,7 +13,9 @@ const getJson: GetJson =
       const json = await response.json()
       if (!schema) return json as T
       const result = await schema['~standard'].validate(json)
-      if (result.issues) throw new Error(result.issues[0].message)
+      if (result.issues) {
+        throw new ParseResponseError('Failed to parse response.json', result.issues)
+      }
       return result.value
     }
 
@@ -26,7 +29,9 @@ const getText: GetText =
       const text = await response.text()
       if (!schema) return text as T
       const result = await schema['~standard'].validate(text)
-      if (result.issues) throw new Error(result.issues[0].message)
+      if (result.issues) {
+        throw new ParseResponseError('Failed to parse response.text', result.issues)
+      }
       return result.value
     }
 

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { JSONValue, PathParams, SearchParams } from './types'
 
 /**
@@ -129,6 +130,18 @@ function typeOf(t: unknown) {
     | 'urlsearchparams'
 }
 
+
+/**
+ * Error thrown when the response cannot be parsed.
+ */
+class ParseResponseError extends Error {
+  constructor(message: string, public issues: readonly StandardSchemaV1.Issue[]) {
+    super(JSON.stringify({ message, issues }, null, 2))
+    this.name = 'ParseResponseError'
+    this.issues = issues
+  }
+}
+
 export {
   addQueryToURL,
   ensureStringBody,
@@ -137,3 +150,4 @@ export {
   replaceURLParams,
   typeOf,
 }
+export { ParseResponseError }


### PR DESCRIPTION
Creates and exports a `ParseResponseError` constructor.
It will help formatting the errors for better DX when the parsing does not succeed.