### PR TITLE
Fix addQueryToURL mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ This little library has plenty of other useful functions that you can use to bui
 ## addQueryToURL
 It receives a URL instance or URL string and an object-like query and returns a new URL with the query appended to it.
 
-It will preserve the original query if it exists and will also preserve the type of the given URL.
+It will preserve the original query if it exists and will also preserve the type of the given URL. When a `URL` object is provided, the original instance is left untouched and a new one is returned.
 
 ```ts
 import { addQueryToURL } from 'make-service'
@@ -510,17 +510,17 @@ addQueryToURL(
 )
 // https://example.com/api/users?role=admin&page=2
 
-addQueryToURL(
-  new URL("https://example.com/api/users"),
-  { page: "2" },
-)
+const url = new URL("https://example.com/api/users")
+addQueryToURL(url, { page: "2" })
 // https://example.com/api/users?page=2
+url.toString()
+// 'https://example.com/api/users'
 
-addQueryToURL(
-  new URL("https://example.com/api/users?role=admin"),
-  { page: "2" },
-)
+const urlWithRole = new URL("https://example.com/api/users?role=admin")
+addQueryToURL(urlWithRole, { page: "2" })
 // https://example.com/api/users?role=admin&page=2
+urlWithRole.toString()
+// 'https://example.com/api/users?role=admin'
 ```
 
 ## ensureStringBody

--- a/package.json
+++ b/package.json
@@ -26,10 +26,7 @@
     "vitest": "latest",
     "zod": "4.0.0-beta.20250420T053007"
   },
-  "files": [
-    "README.md",
-    "./dist/*"
-  ],
+  "files": ["README.md", "./dist/*"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gustavoguichard/make-service.git"

--- a/src/primitives.test.ts
+++ b/src/primitives.test.ts
@@ -15,18 +15,19 @@ describe('addQueryToURL', () => {
   })
 
   it('should add the query object to a URL input', () => {
-    expect(
-      subject
-        .addQueryToURL(new URL('https://example.com/api'), {
-          id: '1',
-        })
-        .toString()
-    ).toEqual(new URL('https://example.com/api?id=1').toString())
-    expect(
-      subject
-        .addQueryToURL(new URL('https://example.com/api'), 'page=2')
-        .toString()
-    ).toEqual(new URL('https://example.com/api?page=2').toString())
+    const base = new URL('https://example.com/api')
+    const result = subject.addQueryToURL(base, { id: '1' })
+    expect(result.toString()).toEqual(
+      new URL('https://example.com/api?id=1').toString()
+    )
+    expect(base.toString()).toEqual('https://example.com/api')
+
+    const base2 = new URL('https://example.com/api')
+    const result2 = subject.addQueryToURL(base2, 'page=2')
+    expect(result2.toString()).toEqual(
+      new URL('https://example.com/api?page=2').toString()
+    )
+    expect(base2.toString()).toEqual('https://example.com/api')
   })
 
   it('should append the query to a URL string that already has QS', () => {
@@ -45,26 +46,29 @@ describe('addQueryToURL', () => {
   })
 
   it('should append the query to a URL instance that already has QS', () => {
-    expect(
-      subject
-        .addQueryToURL(new URL('https://example.com/api?id=1'), {
-          page: '2',
-        })
-        .toString()
-    ).toEqual(new URL('https://example.com/api?id=1&page=2').toString())
-    expect(
-      subject
-        .addQueryToURL(new URL('https://example.com/api?id=1'), 'page=2')
-        .toString()
-    ).toEqual(new URL('https://example.com/api?id=1&page=2').toString())
-    expect(
-      subject
-        .addQueryToURL(
-          new URL('https://example.com/api?id=1'),
-          new URLSearchParams({ page: '2' })
-        )
-        .toString()
-    ).toEqual(new URL('https://example.com/api?id=1&page=2').toString())
+    const base = new URL('https://example.com/api?id=1')
+    const result = subject.addQueryToURL(base, { page: '2' })
+    expect(result.toString()).toEqual(
+      new URL('https://example.com/api?id=1&page=2').toString()
+    )
+    expect(base.toString()).toEqual('https://example.com/api?id=1')
+
+    const base2 = new URL('https://example.com/api?id=1')
+    const result2 = subject.addQueryToURL(base2, 'page=2')
+    expect(result2.toString()).toEqual(
+      new URL('https://example.com/api?id=1&page=2').toString()
+    )
+    expect(base2.toString()).toEqual('https://example.com/api?id=1')
+
+    const base3 = new URL('https://example.com/api?id=1')
+    const result3 = subject.addQueryToURL(
+      base3,
+      new URLSearchParams({ page: '2' })
+    )
+    expect(result3.toString()).toEqual(
+      new URL('https://example.com/api?id=1&page=2').toString()
+    )
+    expect(base3.toString()).toEqual('https://example.com/api?id=1')
   })
 
   it("should return the input in case there's no query", () => {

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -17,9 +17,11 @@ function addQueryToURL<T extends string | URL>(
     return `${url}${separator}${new URLSearchParams(searchParams)}` as T
   }
   if (searchParams && url instanceof URL) {
+    const result = new URL(url.toString())
     for (const [key, value] of new URLSearchParams(searchParams).entries()) {
-      url.searchParams.set(key, value)
+      result.searchParams.set(key, value)
     }
+    return result as T
   }
   return url
 }


### PR DESCRIPTION
## Summary
- avoid mutating URL instances in `addQueryToURL`
- test that `addQueryToURL` doesn't modify the passed URL
- document that `addQueryToURL` returns a new URL

## Testing
- `npm test`
- `npm run lint`
