### PR TITLE
Fix StandardSchema generics inference

### DIFF
--- a/src/internals.ts
+++ b/src/internals.ts
@@ -9,9 +9,11 @@ import type { GetJson, GetText } from './types'
  */
 const getJson: GetJson =
   (response) =>
-  async <T = unknown>(schema?: StandardSchemaV1<T>) => {
+  async <Input = unknown, Output = Input>(
+    schema?: StandardSchemaV1<Input, Output>
+  ) => {
     const json = await response.json()
-    if (!schema) return json as T
+    if (!schema) return json as Output
     const result = await schema['~standard'].validate(json)
     if (result.issues) {
       throw new ParseResponseError(
@@ -28,9 +30,11 @@ const getJson: GetJson =
  */
 const getText: GetText =
   (response) =>
-  async <T extends string = string>(schema?: StandardSchemaV1<T>) => {
+  async <Input extends string = string, Output = Input>(
+    schema?: StandardSchemaV1<Input, Output>
+  ) => {
     const text = await response.text()
-    if (!schema) return text as T
+    if (!schema) return text as Output
     const result = await schema['~standard'].validate(text)
     if (result.issues) {
       throw new ParseResponseError(

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,13 +52,19 @@ type BaseOptions = {
 
 type HTTPMethod = (typeof HTTP_METHODS)[number]
 
-type TypedResponseJson = <T = unknown>(
-  schema?: StandardSchemaV1<T>
-) => Promise<T>
+type TypedResponseJson = <
+  Input = unknown,
+  Output = Input
+>(
+  schema?: StandardSchemaV1<Input, Output>
+) => Promise<Output>
 
-type TypedResponseText = <T extends string = string>(
-  schema?: StandardSchemaV1<T>
-) => Promise<T>
+type TypedResponseText = <
+  Input extends string = string,
+  Output = Input
+>(
+  schema?: StandardSchemaV1<Input, Output>
+) => Promise<Output>
 
 type GetJson = (response: Response) => TypedResponseJson
 type GetText = (response: Response) => TypedResponseText


### PR DESCRIPTION
## Summary
- adjust generics for `TypedResponseJson` and `TypedResponseText`
- update internal parsing helpers accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6850b100d990832e9887bd8a5cc68b8d