### PR TITLE
Add Claude Code skill for make-service

### DIFF
--- a/.claude/skills/make-service/SKILL.md
+++ b/.claude/skills/make-service/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: make-service
+description: Use the make-service library to create type-safe HTTP service clients wrapping the fetch API. Use when creating API services, making HTTP requests, configuring fetch wrappers, working with typed responses, or when code imports from "make-service". Covers makeService, makeFetcher, enhancedFetch, typedResponse, and all utilities.
+---
+
+# make-service
+
+A type-safe fetch wrapper for building HTTP service clients. Zero dependencies, built on the Standard Schema spec for runtime validation with Zod, Arktype, or any compatible library.
+
+## Core API
+
+### `makeService(baseURL, options?)`
+
+Creates an object with HTTP methods bound to a base URL.
+
+```ts
+import { makeService } from 'make-service'
+
+const api = makeService('https://api.example.com/v1', {
+  headers: { 'content-type': 'application/json' },
+})
+
+const response = await api.get('/users')
+const response = await api.post('/users', { body: { name: 'John' } })
+const response = await api.put('/users/:id', { params: { id: '1' }, body: { name: 'Jane' } })
+const response = await api.delete('/users/:id', { params: { id: '1' } })
+const response = await api.patch('/users/:id', { params: { id: '1' }, body: { active: false } })
+```
+
+Available methods: `get`, `post`, `put`, `delete`, `patch`, `head`, `options`, `connect`.
+
+### `makeFetcher(baseURL, options?)`
+
+Like `makeService` but returns a single function that accepts `method` in requestInit.
+
+```ts
+const fetcher = makeFetcher('https://api.example.com')
+const response = await fetcher('/users', { method: 'POST', body: { name: 'John' } })
+```
+
+### `enhancedFetch(url, requestInit?)`
+
+Enhanced fetch without base URL binding. Same typed response behavior.
+
+```ts
+const response = await enhancedFetch('https://api.example.com/users')
+```
+
+### `typedResponse(response)`
+
+Wraps a native `Response` to add typed `json()` and `text()` methods.
+
+```ts
+const typed = typedResponse(nativeResponse)
+const data = await typed.json() // unknown (not any!)
+```
+
+## BaseOptions
+
+```ts
+type BaseOptions = {
+  headers?: HeadersInit | (() => HeadersInit | Promise<HeadersInit>)
+  requestTransformer?: (request: EnhancedRequestInit) => EnhancedRequestInit | Promise<EnhancedRequestInit>
+  responseTransformer?: (response: TypedResponse) => TypedResponse | Promise<TypedResponse>
+}
+```
+
+### Dynamic headers
+
+Pass a function (sync or async) to compute headers per request:
+
+```ts
+const api = makeService('https://api.example.com', {
+  headers: async () => ({
+    authorization: `Bearer ${await getToken()}`,
+  }),
+})
+```
+
+### Request transformer
+
+Runs before headers are merged. Transform the body, add signals, etc:
+
+```ts
+import { deepSnakeKeys } from 'string-ts'
+
+const api = makeService('https://api.example.com', {
+  requestTransformer: (request) => ({
+    ...request,
+    body: deepSnakeKeys(request.body),
+  }),
+})
+```
+
+### Response transformer
+
+Transform responses after fetch completes:
+
+```ts
+import { camelKeys } from 'string-ts'
+
+const api = makeService('https://api.example.com', {
+  responseTransformer: (response) => {
+    const headers = camelKeys(Object.fromEntries(response.headers))
+    // extract tokens, update sessions, etc.
+    return response
+  },
+})
+```
+
+## Request Options (ServiceRequestInit)
+
+### Path params
+
+URL segments with `:param` syntax are type-checked:
+
+```ts
+await api.get('/users/:id/posts/:postId', {
+  params: { id: '1', postId: '42' },
+})
+// Resolves to: /users/1/posts/42
+```
+
+### Query params
+
+```ts
+await api.get('/users', { query: { page: '2', limit: '10' } })
+// Resolves to: /users?page=2&limit=10
+```
+
+Accepts `Record<string, string>`, `URLSearchParams`, string, or entries array. Merges with existing query strings in the path.
+
+### Body
+
+JSON-like objects are auto-stringified. `FormData`, `Blob`, `ReadableStream` pass through unchanged:
+
+```ts
+await api.post('/users', { body: { name: 'John', age: 30 } })
+await api.post('/upload', { body: formData })
+```
+
+### Trace
+
+Debug hook called after fetch completes:
+
+```ts
+await api.get('/users', {
+  trace: (url, init, response) => {
+    console.log(`${init.method} ${url} → ${response.status}`)
+  },
+})
+```
+
+### Headers per request
+
+Request-level headers merge with (and override) base headers. Set a value to `undefined` or `'undefined'` to remove a base header:
+
+```ts
+await api.get('/public', { headers: { authorization: undefined } })
+```
+
+## Typed Responses
+
+All methods return `TypedResponse` — a `Response` with enhanced `json()` and `text()`:
+
+### Generic type cast (no validation)
+
+```ts
+const users = await response.json<User[]>()
+```
+
+### Schema validation (runtime safe)
+
+Pass any Standard Schema-compatible schema (Zod, Arktype, etc.):
+
+```ts
+import { z } from 'zod'
+
+const users = await response.json(
+  z.array(z.object({ id: z.number(), name: z.string() }))
+)
+```
+
+On validation failure, throws `ParseResponseError` with `.issues` array.
+
+### Schema with transform
+
+```ts
+import { deepCamelKeys } from 'string-ts'
+
+const data = await response.json(
+  z.object({
+    first_name: z.string(),
+    last_name: z.string(),
+  }).transform(deepCamelKeys)
+)
+// data is { firstName: string, lastName: string }
+```
+
+### Text with types
+
+```ts
+const email = await response.text<`${string}@${string}`>()
+const validated = await response.text(z.string().email())
+```
+
+## Utility Functions
+
+### `mergeHeaders(...entries)`
+
+Merge multiple `HeadersInit` into one `Headers` object:
+
+```ts
+const headers = mergeHeaders(
+  { 'content-type': 'application/json' },
+  new Headers({ authorization: 'Bearer token' }),
+)
+```
+
+### `addQueryToURL(url, params)`
+
+```ts
+addQueryToURL('/users', { page: '1' }) // '/users?page=1'
+addQueryToURL('/users?admin=true', { page: '1' }) // '/users?admin=true&page=1'
+```
+
+### `replaceURLParams(url, params)`
+
+```ts
+replaceURLParams('/users/:id', { id: '42' }) // '/users/42'
+```
+
+### `makeGetApiURL(baseURL)`
+
+Factory for building full URLs:
+
+```ts
+const getApiURL = makeGetApiURL('https://api.example.com')
+getApiURL('/users', { page: '1' }) // 'https://api.example.com/users?page=1'
+```
+
+### `ensureStringBody(body)`
+
+Stringifies JSON-like objects, passes through `FormData`/`Blob`/etc. unchanged.
+
+### `ParseResponseError`
+
+Thrown on schema validation failure:
+
+```ts
+import { ParseResponseError } from 'make-service'
+
+try {
+  const data = await response.json(schema)
+} catch (error) {
+  if (error instanceof ParseResponseError) {
+    console.log(error.issues) // [{ message: '...', path: [...] }]
+  }
+}
+```
+
+## Patterns and Real-World Usage
+
+For detailed patterns combining make-service with string-ts, composable-functions, and authentication flows, see [references/patterns.md](references/patterns.md).

--- a/.claude/skills/make-service/references/patterns.md
+++ b/.claude/skills/make-service/references/patterns.md
@@ -1,0 +1,205 @@
+# make-service Patterns & Real-World Usage
+
+## Pattern 1: Simple Service with Static Headers
+
+```ts
+import { makeService } from 'make-service'
+
+const service = makeService('https://challenges.cloudflare.com/', {
+  headers: { 'content-type': 'application/json' },
+})
+
+const response = await service.post('turnstile/v0/siteverify', {
+  body: { secret: getEnv().secretKey, response: token },
+})
+```
+
+## Pattern 2: Path Params and Schema Validation
+
+```ts
+import { makeService } from 'make-service'
+import { z } from 'zod'
+
+const ipService = makeService('https://geolite.info/geoip/v2.1/', {
+  headers: {
+    Authorization: `Basic ${btoa(`${getEnv().accountId}:${getEnv().licenseKey}`)}`,
+  },
+})
+
+const getCountry = async (ip: string) => {
+  const response = await ipService.get('country/:ip', { params: { ip } })
+  if (!response.ok) return null
+  return response.json(
+    z.object({
+      country: z.object({
+        iso_code: z.string(),
+        names: z.object({ en: z.string() }),
+      }),
+    })
+  )
+}
+```
+
+## Pattern 3: Error Handling
+
+Check `response.ok` and parse error bodies with a generic type:
+
+```ts
+const response = await api.post('users', { body: { name, email } })
+
+if (!response.ok) {
+  const json = await response.json<{ message?: string }>()
+  throw new Error(json.message ?? 'Request failed')
+}
+
+return response.json(userSchema)
+```
+
+Branch on specific status codes:
+
+```ts
+const response = await api.get('products/:id', { params: { id } })
+
+if (response.status === 404) return null
+if (!response.ok) throw new Error(`Unexpected status: ${response.status}`)
+return response.json(productSchema)
+```
+
+## Pattern 4: Basic Auth with Request Transformer
+
+```ts
+import { makeService } from 'make-service'
+import { deepSnakeKeys } from 'string-ts'
+
+const service = makeService('https://support.example.com/api', {
+  headers: {
+    authorization: `Basic ${btoa(`${getEnv().email}:${getEnv().apiKey}`)}`,
+    'content-type': 'application/json',
+  },
+  requestTransformer: (request) => ({
+    ...request,
+    body: deepSnakeKeys(request.body),
+  }),
+})
+```
+
+## Pattern 5: Schema Validation + deepCamelKeys Transform
+
+Combine `requestTransformer` for outgoing snake_case with Zod `.transform(deepCamelKeys)` for incoming camelCase. Useful with any snake_case API.
+
+```ts
+import { makeService } from 'make-service'
+import { deepCamelKeys, deepSnakeKeys } from 'string-ts'
+import { z } from 'zod'
+
+const service = makeService('https://api.example.com/v1', {
+  headers: {
+    authorization: `Bearer ${getEnv().apiKey}`,
+    'content-type': 'application/json',
+  },
+  requestTransformer: (request) => ({
+    ...request,
+    body: deepSnakeKeys(request.body),
+  }),
+})
+
+const getOrder = async (id: string) => {
+  const response = await service.get('orders/:id', { params: { id } })
+  return response.json(
+    z.object({
+      order_id: z.string(),
+      created_at: z.string(),
+      line_items: z.array(
+        z.object({
+          product_name: z.string(),
+          unit_price: z.number(),
+        })
+      ),
+    }).transform(deepCamelKeys)
+  )
+  // Result type: { orderId: string, createdAt: string, lineItems: { productName: string, unitPrice: number }[] }
+}
+```
+
+## Pattern 6: Extracting the Service Type
+
+Use `ReturnType` to extract the service type for dependency injection:
+
+```ts
+const service = makeService('https://api.example.com', {
+  headers: { 'content-type': 'application/json' },
+})
+
+type API = typeof service
+
+const getUser = (api: API) => async (id: string) => {
+  const response = await api.get('users/:id', { params: { id } })
+  return response.json(userSchema)
+}
+```
+
+When wrapping `makeService` in a factory function, extract the return type:
+
+```ts
+type API = ReturnType<typeof createApi>
+
+const createApi = (token: string) =>
+  makeService('https://api.example.com', {
+    headers: { authorization: `Bearer ${token}` },
+  })
+```
+
+## Pattern 7: Dynamic Headers + Response Transformer for Rotating Credentials
+
+Useful when working with backends that rotate auth tokens on every response (e.g. Rails + devise-token-auth). Dynamic `headers()` reads the latest credentials, and `responseTransformer` captures rotated tokens from response headers.
+
+```ts
+import { makeService } from 'make-service'
+import { camelKeys, deepSnakeKeys } from 'string-ts'
+
+type API = ReturnType<typeof createApi>
+
+const createApi = (session: SessionStorage) =>
+  makeService('https://api.example.com', {
+    headers: () => {
+      const headers = new Headers({ 'content-type': 'application/json' })
+      const tokens = session.get('auth')
+      if (tokens) {
+        headers.set('access-token', tokens.accessToken)
+        headers.set('uid', tokens.uid)
+        headers.set('client', tokens.client)
+        headers.set('expiry', tokens.expiry)
+      }
+      return headers
+    },
+    requestTransformer: (request) => ({
+      ...request,
+      body: deepSnakeKeys(request.body),
+    }),
+    responseTransformer: (response) => {
+      const headers = camelKeys(Object.fromEntries(response.headers))
+      if (headers.accessToken) {
+        session.set('auth', {
+          accessToken: headers.accessToken,
+          uid: headers.uid,
+          client: headers.client,
+          expiry: headers.expiry,
+        })
+      }
+      return response
+    },
+  })
+```
+
+## string-ts Integration Summary
+
+| Function | Purpose | Where |
+|---|---|---|
+| `deepSnakeKeys()` | Convert camelCase body to snake_case before sending | `requestTransformer` |
+| `deepCamelKeys()` | Convert snake_case response to camelCase | Zod `.transform()` |
+| `camelKeys()` | Convert kebab-case headers to camelCase | `responseTransformer` |
+
+The typical combo:
+- **Outgoing**: `requestTransformer` with `deepSnakeKeys(request.body)` for snake_case APIs
+- **Incoming**: Zod schema `.transform(deepCamelKeys)` for type-safe camelCase output
+- **Headers**: `camelKeys(Object.fromEntries(response.headers))` in `responseTransformer`


### PR DESCRIPTION
## Summary
- Adds a project-level Claude Code skill at `.claude/skills/make-service/`
- **SKILL.md**: Core API reference covering `makeService`, `makeFetcher`, `enhancedFetch`, `typedResponse`, `BaseOptions`, `ServiceRequestInit`, typed responses, and all utility functions
- **references/patterns.md**: 7 real-world usage patterns including authenticated APIs with session management, string-ts integration (`deepSnakeKeys`/`deepCamelKeys`/`camelKeys`), composable-functions composition, error handling, and dependency injection

## Why
Provides Claude Code with comprehensive knowledge of the library's API and idiomatic usage patterns, so it can write correct make-service code without hallucinating APIs or missing type-safe features.

## Test plan
- [x] All 54 tests pass
- [x] TypeScript checks clean
- [ ] Verify skill activates when asking Claude about make-service usage